### PR TITLE
restrict onnxruntime version on win32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+### v1.3.1
+Release date: 2025-10-31
+- Avoid onnxruntime bug on win32
+
 ### v1.3.0
 Release date: 2025-09-23
 - New export feature for darktable XMP files

--- a/autolevels/autolevels.py
+++ b/autolevels/autolevels.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 from pathlib import Path
 from argparse import ArgumentParser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "autolevels"
-version = "1.3.0"
+version = "1.3.1"
 description = "A tool for automatic photo enhancement using curve corrections."
 readme = "README.md"
 authors = [{name = "Marius Wanko", email = "marius.wanko@gmail.com"}]
@@ -16,7 +16,8 @@ dependencies = [
     "piexif>=1.1.1,<2.0.0",
     "opencv-python",
     "h5py",
-    "onnxruntime",
+    "onnxruntime; sys_platform != 'win32'",
+    "onnxruntime<1.21.0; sys_platform == 'win32'",
 ]
 classifiers = [
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
On Windows, onnxruntime versions 1.21 ... 1.23.2 fail on import: "DLL load failed while importing onnxruntime_pybind11_state.